### PR TITLE
Make Mesh vertex and face attrs non-Options

### DIFF
--- a/lib/geom/src/mesh.rs
+++ b/lib/geom/src/mesh.rs
@@ -1,8 +1,8 @@
-use math::vec::{Vec4, ZERO};
-use math::mat::Mat4;
 use math::Linear;
+use math::mat::Mat4;
+use math::vec::{Vec4, ZERO};
 
-pub trait VertexAttr : Linear<f32> + Copy + Default {
+pub trait VertexAttr: Linear<f32> + Copy {
     fn transform(&mut self, mat: &Mat4);
 }
 
@@ -12,18 +12,33 @@ impl VertexAttr for Vec4 {
     }
 }
 
-#[derive(Clone)]
+impl VertexAttr for () {
+    fn transform(&mut self, _: &Mat4) {}
+}
+
+#[derive(Default, Debug, Clone)]
 pub struct Mesh<VA = (), FA = ()> {
     pub verts: Vec<Vec4>,
     pub faces: Vec<[usize; 3]>,
-    pub vertex_attrs: Option<Vec<VA>>,
-    pub face_attrs: Option<Vec<FA>>,
+    pub vertex_attrs: Vec<VA>,
+    pub face_attrs: Vec<FA>,
 }
 
 
+impl Mesh {
+    pub fn from_verts_and_faces(verts: Vec<Vec4>, faces: Vec<[usize; 3]>) -> Mesh {
+        Mesh {
+            face_attrs: vec![(); faces.len()],
+            vertex_attrs: vec![(); verts.len()],
+            verts,
+            faces,
+        }
+    }
+}
+
 impl<VA, FA> Mesh<VA, FA> {
     pub fn new() -> Self {
-        Mesh { verts: vec![], faces: vec![], vertex_attrs: None, face_attrs: None }
+        Mesh { verts: vec![], faces: vec![], vertex_attrs: vec![], face_attrs: vec![] }
     }
 
     pub fn faces(&self) -> impl Iterator<Item=&[usize; 3]> + '_ {
@@ -37,30 +52,29 @@ impl<VA, FA> Mesh<VA, FA> {
     }
 
     pub fn validate(self) -> Result<Self, String> {
-        if let Some(idx) = self.faces().flatten().find(|&&idx| idx >= self.verts.len()) {
+        let Mesh { verts, faces, vertex_attrs, face_attrs } = &self;
+
+        if let Some(idx) = faces.iter().flatten().find(|&&idx| idx >= verts.len()) {
             return Err(format!("Vertex index out of bounds: {:?}", idx));
         }
-        if let Some(face) = self.faces().find(|&[a, b, c]| a == b || b == c || a == c) {
+        if let Some(face) = faces.iter().find(|&[a, b, c]| a == b || b == c || a == c) {
             return Err(format!("Degenerate face: {:?}", face));
         }
 
-        let mut verts = vec![false; self.verts.len()];
-        for idx in self.faces().flatten() {
+        let mut verts = vec![false; verts.len()];
+        for idx in faces.iter().flatten() {
             verts[*idx] = true;
         }
         if let Some((idx, _)) = verts.iter().enumerate().find(|(_, &v)| !v) {
             return Err(format!("Unused vertex: {:?}", idx));
         }
 
-        if let Some(attrs) = &self.face_attrs {
-            if attrs.len() != self.faces.len() {
-                return Err(format!("Missing or extra face attrs"));
-            }
+        if face_attrs.len() != faces.len() {
+            return Err(format!("Missing or extra face attrs"));
         }
-        if let Some(attrs) = &self.vertex_attrs {
-            if attrs.len() != self.verts.len() {
-                return Err(format!("Missing or extra vertex attrs"));
-            }
+
+        if vertex_attrs.len() != verts.len() {
+            return Err(format!("Missing or extra vertex attrs"));
         }
 
         Ok(self)
@@ -82,8 +96,8 @@ impl<VA, FA> Mesh<VA, FA> {
         Mesh {
             verts: self.verts,
             faces: self.faces,
-            vertex_attrs: Some(vertex_norms.into_iter().map(Vec4::normalize).collect()),
-            face_attrs: Some(face_norms.into_iter().map(Vec4::normalize).collect()),
+            vertex_attrs: vertex_norms.into_iter().map(Vec4::normalize).collect(),
+            face_attrs: face_norms.into_iter().map(Vec4::normalize).collect(),
         }
     }
 }
@@ -92,4 +106,6 @@ impl<VA, FA> Mesh<VA, FA> {
 mod tests {
     // use super::*;
     // TODO tests
+    #[test]
+    fn test() {}
 }

--- a/lib/geom/src/solids.rs
+++ b/lib/geom/src/solids.rs
@@ -5,8 +5,8 @@ use math::vec::*;
 use crate::mesh::Mesh;
 
 pub fn unit_cube() -> Mesh {
-    Mesh {
-        verts: vec![
+    Mesh::from_verts_and_faces(
+        vec![
             // left
             pt(-1.0, -1.0, -1.0), // 000
             pt(-1.0, -1.0, 1.0),  // 001
@@ -18,7 +18,7 @@ pub fn unit_cube() -> Mesh {
             pt(1.0, 1.0, -1.0),  // 110
             pt(1.0, 1.0, 1.0),   // 111
         ],
-        faces: vec![
+        vec![
             // left
             [0b000, 0b011, 0b001], [0b000, 0b010, 0b011],
             // right
@@ -31,15 +31,13 @@ pub fn unit_cube() -> Mesh {
             [0b000, 0b110, 0b010], [0b000, 0b100, 0b110],
             // back
             [0b001, 0b011, 0b111], [0b001, 0b111, 0b101],
-        ],
-        vertex_attrs: None,
-        face_attrs: None,
-    }
+        ]
+    )
 }
 
 pub fn unit_octahedron() -> Mesh {
-    Mesh {
-        verts: vec![
+    Mesh::from_verts_and_faces(
+        vec![
             pt(-1.0, 0.0, 0.0),
             pt(0.0, -1.0, 0.0),
             pt(0.0, 0.0, -1.0),
@@ -47,7 +45,7 @@ pub fn unit_octahedron() -> Mesh {
             pt(0.0, 0.0, 1.0),
             pt(1.0, 0.0, 0.0),
         ],
-        faces: vec![
+        vec![
             [0, 1, 2],
             [0, 2, 3],
             [0, 3, 4],
@@ -56,10 +54,8 @@ pub fn unit_octahedron() -> Mesh {
             [5, 3, 2],
             [5, 4, 3],
             [5, 1, 4],
-        ],
-        vertex_attrs: None,
-        face_attrs: None,
-    }
+        ]
+    )
 }
 
 pub fn unit_sphere(parallels: usize, meridians: usize) -> Mesh {
@@ -103,12 +99,7 @@ pub fn unit_sphere(parallels: usize, meridians: usize) -> Mesh {
     }
     faces.push([verts.len() - meridians - 1, verts.len() - 1, verts.len() - 2]);
 
-    Mesh {
-        verts,
-        faces,
-        vertex_attrs: None,
-        face_attrs: None,
-    }
+    Mesh::from_verts_and_faces(verts, faces)
 }
 
 pub fn torus(minor_r: f32, pars: usize, mers: usize) -> Mesh {
@@ -150,12 +141,7 @@ pub fn torus(minor_r: f32, pars: usize, mers: usize) -> Mesh {
     faces.push([l - pars, pars - 1, 0]);
     faces.push([l - pars, l - 1, pars - 1]);
 
-    Mesh {
-        verts,
-        faces,
-        vertex_attrs: None,
-        face_attrs: None,
-    }
+    Mesh::from_verts_and_faces(verts, faces)
 }
 
 #[cfg(feature = "teapot")]
@@ -182,10 +168,10 @@ pub fn teapot() -> Mesh<Vec4> {
         verts: VERTICES.iter()
                        .map(|&[x, y, z]| pt(x, y, z))
                        .collect(),
-        vertex_attrs: Some(VERTEX_NORMALS.iter()
-                                         .map(|&[x, y, z]| dir(x, y, z))
-                                         .collect()),
-        face_attrs: Some(vec![(); n_faces])
+        vertex_attrs: VERTEX_NORMALS.iter()
+                                    .map(|&[x, y, z]| dir(x, y, z))
+                                    .collect(),
+        face_attrs: vec![(); n_faces]
     }
 }
 

--- a/lib/render/src/hsr.rs
+++ b/lib/render/src/hsr.rs
@@ -10,12 +10,10 @@ where VA: Copy + Linear<f32>, FA: Copy, {
 
     let Mesh { verts, faces, vertex_attrs, face_attrs, .. } = mesh;
 
-    let vertex_attrs = vertex_attrs.as_mut().unwrap(); // FIXME
-
     let mut visible_faces = Vec::with_capacity(faces.len() / 2);
     let mut visible_attrs = Vec::with_capacity(faces.len() / 2);
 
-    for (&[a, b, c], &fa) in faces.iter().zip(face_attrs.as_ref().unwrap()) {
+    for (&[a, b, c], &mut fa) in faces.iter().zip(face_attrs) {
         match face_visibility(&[verts[a], verts[b], verts[c]]) {
             FaceVis::Hidden => {
                 continue
@@ -46,7 +44,7 @@ where VA: Copy + Linear<f32>, FA: Copy, {
         }
     }
     mesh.faces = visible_faces;
-    mesh.face_attrs = Some(visible_attrs);
+    mesh.face_attrs = visible_attrs;
 }
 
 


### PR DESCRIPTION
This removes a few explicit unwraps and other dodgy logic.
Meshes without attrs should use () as the attr type.
Vec<()> never allocates and is basically optimized out
to nothingness, so there is no overhead.