### PR TITLE
Clean up Renderer transform code and API

### DIFF
--- a/benches/renderer.rs
+++ b/benches/renderer.rs
@@ -8,14 +8,14 @@ const W: usize = 128;
 
 fn renderer() -> Renderer {
     let mut rdr = Renderer::new();
-    rdr.set_projection(perspective(1.0, 10.0, 1., 1.));
-    rdr.set_viewport(viewport(0.0, 0.0, W as f32, W as f32));
+    rdr.projection = perspective(1.0, 10.0, 1., 1.);
+    rdr.viewport = viewport(0.0, 0.0, W as f32, W as f32);
     rdr
 }
 
 fn torus(c: &mut Criterion) {
     let mut rdr = renderer();
-    rdr.set_transform(scale(4., 4., 4.));
+    rdr.modelview = scale(4., 4., 4.);
 
     let mesh = solids::torus(0.2, 9, 9);
 
@@ -58,7 +58,7 @@ fn scene(c: &mut Criterion) {
 
 fn gouraud_fillrate(c: &mut Criterion) {
     let mut rdr = renderer();
-    rdr.set_transform(scale(2., 2., 2.) * &translate(0.0, 0.0, 6.0));
+    rdr.modelview = scale(2., 2., 2.) * &translate(0.0, 0.0, 6.0);
     let mesh = solids::unit_cube().with_vertex_attrs([
         RED, GREEN, BLUE, RED, GREEN, BLUE, RED, GREEN
     ].iter().copied());

--- a/examples/sdl/checkers.rs
+++ b/examples/sdl/checkers.rs
@@ -79,9 +79,9 @@ fn main() {
 
     let mut rdr = Renderer::new();
     rdr.options.perspective_correct = true;
-    rdr.set_projection(perspective(0.1, 50., w as f32 / h as f32, PI / 2.0));
-    rdr.set_viewport(viewport(margin as f32, (h - margin) as f32,
-                              (w - margin) as f32, margin as f32));
+    rdr.projection = perspective(0.1, 50., w as f32 / h as f32, PI / 2.0);
+    rdr.viewport = viewport(margin as f32, (h - margin) as f32,
+                            (w - margin) as f32, margin as f32);
 
     let tex = {
         let (b, w) = (gray(0x33), gray(0xFF));

--- a/examples/sdl/teapot.rs
+++ b/examples/sdl/teapot.rs
@@ -46,9 +46,9 @@ fn main() {
     let mut trans = dir(0.0, 0.0, 40.0);
 
     let mut rdr = Renderer::new();
-    rdr.set_projection(perspective(1., 60., w as f32 / h as f32, PI / 3.0));
-    rdr.set_viewport(viewport(margin as f32, (h - margin) as f32,
-                              (w - margin) as f32, margin as f32));
+    rdr.projection = perspective(1., 60., w as f32 / h as f32, PI / 3.0);
+    rdr.viewport = viewport(margin as f32, (h - margin) as f32,
+                            (w - margin) as f32, margin as f32);
 
     let mut runner = SdlRunner::new(w as u32, h as u32).unwrap();
 

--- a/lib/math/src/transform.rs
+++ b/lib/math/src/transform.rs
@@ -1,4 +1,20 @@
-use crate::mat::*;
+use crate::{mat::*, vec::Vec4};
+
+pub trait Transform {
+    fn transform(&mut self, m: &Mat4);
+}
+
+impl Transform for Vec4 {
+    fn transform(&mut self, m: &Mat4) {
+        *self = m * *self;
+    }
+}
+
+impl<T: Transform> Transform for [T] {
+    fn transform(&mut self, m: &Mat4) {
+        for x in self { x.transform(m); }
+    }
+}
 
 pub fn scale(x: f32, y: f32, z: f32) -> Mat4 {
     let mut m = Mat4::identity();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -24,9 +24,9 @@ fn render<VA, FA>(mesh: Mesh<VA, FA>) -> String
 where VA: Copy + Linear<f32>, FA: Copy + Debug
 {
     let mut rdr = Renderer::new();
-    rdr.set_transform(translate(0.0, 0.0, 4.0));
-    rdr.set_projection(perspective(1.0, 10.0, 1., 1.));
-    rdr.set_viewport(viewport(0.0, 0.0, 10.0, 10.0));
+    rdr.modelview = translate(0.0, 0.0, 4.0);
+    rdr.projection = perspective(1.0, 10.0, 1., 1.);
+    rdr.viewport = viewport(0.0, 0.0, 10.0, 10.0);
 
     let mesh = mesh.validate().expect("Invalid mesh!");
 
@@ -47,8 +47,8 @@ where VA: Copy + Linear<f32>, FA: Copy
     const W: usize = 50;
     const H: usize = 20;
     let mut rdr = Renderer::new();
-    rdr.set_projection(perspective(1.0, 100.0, 1.0, 0.5 * PI));
-    rdr.set_viewport(viewport(0.0, 0.0, W as f32, H as f32));
+    rdr.projection = perspective(1.0, 100.0, 1.0, 0.5 * PI);
+    rdr.viewport = viewport(0.0, 0.0, W as f32, H as f32);
 
     let stats = rdr.render_scene(
         &scene,


### PR DESCRIPTION
* Rename "transform" to "modelview"
* Remove setters in favor of pub fields
* Remove superfluous private methods
* Add Transform trait for transformable objects