### PR TITLE
Implement z-buffering (#2)

### DIFF
--- a/benches/renderer.rs
+++ b/benches/renderer.rs
@@ -2,7 +2,8 @@ use criterion::*;
 
 use geom::solids;
 use math::transform::*;
-use render::{color::*, Obj, Renderer, Scene};
+use render::{color::*, Obj, Renderer, Scene, Raster};
+use render::raster::Fragment;
 
 const W: usize = 128;
 
@@ -23,8 +24,11 @@ fn torus(c: &mut Criterion) {
     c.bench_function("torus", |b| {
         b.iter(|| rdr.render(
             &mesh,
-            &|_, _| BLACK,
-            &mut |x, y, _| buf[W * y + x] = '#'
+            &mut Raster {
+                shade: |_, _| BLACK,
+                test: |_| true,
+                output: |x, y, _| buf[W * y + x] = '#',
+            }
         ))
     });
     eprintln!("Stats/s: {}", rdr.stats.avg_per_sec());
@@ -49,8 +53,11 @@ fn scene(c: &mut Criterion) {
     c.bench_function("scene", |b| {
         b.iter(|| rdr.render_scene(
             &scene,
-            &|_, _| BLACK,
-            &mut |x, y, _| buf[W * y + x] = '#'
+            &mut Raster {
+                shade: |_, _| BLACK,
+                test: |_| true,
+                output: |x, y, _| buf[W * y + x] = '#'
+            }
         ))
     });
     eprintln!("Stats/s: {}", rdr.stats.avg_per_sec());
@@ -67,8 +74,11 @@ fn gouraud_fillrate(c: &mut Criterion) {
     c.bench_function("gouraud", |b| {
         b.iter(|| rdr.render(
             &mesh,
-            &|frag, _| frag.varying,
-            &mut |x, y, col| buf[W * y + x] = col
+            &mut Raster {
+                shade: |frag: Fragment<_>, _| frag.varying,
+                test: |_| true,
+                output: |x, y, col| buf[W * y + x] = col
+            }
         ))
     });
     eprintln!("Stats/frame: {}", rdr.stats.avg_per_frame());

--- a/examples/sdl/checkers.rs
+++ b/examples/sdl/checkers.rs
@@ -99,16 +99,17 @@ fn main() {
 
     let mut runner = SdlRunner::new(w as u32, h as u32).unwrap();
 
-    runner.run(|mut frame| {
-        let shade = |frag: Fragment<_>, color: Color| {
-            color * tex.sample(frag.varying)
-        };
+    runner.run(|Frame { mut buf, zbuf, pressed_keys, delta_t, .. }| {
 
-        rdr.render_scene(&scene, &shade, &mut frame.buf);
+        rdr.render_scene(&scene, &mut Raster {
+            shade: |frag: Fragment<_>, c| c * tex.sample(frag.varying),
+            test: |frag| zbuf.test(frag),
+            output: |x, y, c| buf.plot(x, y, c),
+        });
 
-        for scancode in frame.pressed_keys {
-            let t = -8. * frame.delta_t;
-            let r = -2. * frame.delta_t;
+        for scancode in pressed_keys {
+            let t = -8. * delta_t;
+            let r = -2. * delta_t;
             use Scancode::*;
             let cam = &mut scene.camera;
             match scancode {

--- a/examples/sdl/runner.rs
+++ b/examples/sdl/runner.rs
@@ -5,41 +5,26 @@ use sdl2::event::Event;
 use sdl2::keyboard::{Keycode, Scancode};
 use sdl2::pixels::Color as SdlColor;
 use sdl2::rect::Rect;
-use sdl2::video::{Window, WindowSurfaceRef};
+use sdl2::video::Window;
 
-use render::{color::Color, Plot, Stats};
+use render::{Buffer, DepthBuf, Stats};
 use Run::*;
 
 pub struct SdlRunner {
     #[allow(unused)]
     sdl: Sdl,
     window: Window,
+    zbuf: DepthBuf,
     event_pump: EventPump,
     start: Instant,
 }
 
 pub struct Frame<'a> {
-    pub buf: Buf<'a>,
+    pub buf: Buffer<u8, &'a mut [u8]>,
+    pub zbuf: &'a mut DepthBuf,
     pub delta_t: f32,
     pub events: Vec<Event>,
     pub pressed_keys: Vec<Scancode>,
-}
-
-pub struct Buf<'a> {
-    width: usize,
-    #[allow(unused)]
-    height: usize,
-    data: &'a mut[u8]
-}
-
-impl<'a> Plot for Buf<'a> {
-    fn plot(&mut self, x: usize, y: usize, c: Color) {
-        let idx = 4 * (self.width * y + x);
-        let [_, r, g, b] = c.to_argb();
-        self.data[idx + 0] = b;
-        self.data[idx + 1] = g;
-        self.data[idx + 2] = r;
-    }
 }
 
 #[derive(Eq, PartialEq)]
@@ -54,45 +39,53 @@ impl SdlRunner {
             .map_err(|e| e.to_string())?;
         let event_pump = sdl.event_pump()?;
 
-        Ok(SdlRunner { sdl, window, event_pump, start: Instant::now() })
+        Ok(SdlRunner {
+            sdl,
+            window,
+            event_pump,
+            zbuf: DepthBuf::new(win_w as usize, win_h as usize),
+            start: Instant::now(),
+        })
     }
 
     pub fn run<F>(&mut self, mut frame_fn: F) -> Result<(), String>
-    where F: FnMut(Frame) -> Result<Run, String>
+        where F: FnMut(Frame) -> Result<Run, String>
     {
         let mut clock = Instant::now();
         loop {
             let events = self.event_pump.poll_iter()
-                             .collect::<Vec<_>>();
+                .collect::<Vec<_>>();
             let pressed_keys = self.event_pump.keyboard_state()
-                                   .pressed_scancodes().collect();
+                .pressed_scancodes().collect();
 
             if events.iter().any(Self::is_quit) {
-                return Ok(())
+                return Ok(());
             }
 
-            let mut surf = self.surface()?;
+            let mut surf = self.window.surface(&self.event_pump)?;
             let rect = Rect::new(0, 0, surf.width(), surf.height());
             surf.fill_rect(rect, SdlColor::GREY)?;
 
-            let now = Instant::now();
-            let delta_t = (now - clock).as_secs_f32();
-            clock = now;
+            let zbuf = &mut self.zbuf;
+            zbuf.clear();
 
+            let delta_t = clock.elapsed().as_secs_f32();
+            clock = Instant::now();
+
+            let w = surf.width() as usize;
             let frame = Frame {
-                buf: Buf {
-                    width: surf.width() as usize,
-                    height: surf.height() as usize,
-                    data: surf.without_lock_mut().unwrap(),
-                },
-                delta_t, events, pressed_keys,
+                buf: Buffer::borrow(w, surf.without_lock_mut().unwrap()),
+                zbuf,
+                delta_t,
+                events,
+                pressed_keys,
             };
 
             let res = frame_fn(frame)?;
-            self.surface()?.update_window()?;
+            surf.update_window()?;
 
             if res == Quit {
-                return Ok(())
+                return Ok(());
             }
         }
     }
@@ -117,12 +110,8 @@ impl SdlRunner {
         println!(" Average fps   │ {:.2}\n", frames as f32 / elapsed);
     }
 
-    fn surface(&self) -> Result<WindowSurfaceRef, String> {
-        self.window.surface(&self.event_pump)
-    }
-
     fn is_quit(e: &Event) -> bool {
         matches!(e, Event::Quit { .. }
-            | Event::KeyDown { keycode: Some(Keycode::Escape), .. })
+           | Event::KeyDown { keycode: Some(Keycode::Escape), .. })
     }
 }

--- a/lib/render/src/lib.rs
+++ b/lib/render/src/lib.rs
@@ -1,3 +1,4 @@
+use std::ops::DerefMut;
 use std::time::Instant;
 
 use color::Color;
@@ -5,6 +6,7 @@ use geom::mesh::Mesh;
 use math::Linear;
 use math::mat::Mat4;
 use math::transform::Transform;
+use math::vec::Vec4;
 pub use stats::Stats;
 
 use crate::hsr::Visibility;
@@ -18,15 +20,43 @@ pub mod stats;
 pub mod tex;
 pub mod vary;
 
-pub trait Plot {
-    fn plot(&mut self, x: usize, y: usize, c: Color);
+pub trait RasterOps<VA: Copy, FA> {
+    fn shade(&mut self, frag: Fragment<VA>, uniform: FA) -> Color;
+
+    fn test(&mut self, _frag: Fragment<VA>) -> bool { true }
+
+    // TODO
+    // fn blend(&mut self, _x: usize, _y: usize, c: Color) -> Color { c }
+
+    fn output(&mut self, x: usize, y: usize, c: Color);
 }
 
-impl<F: FnMut(usize, usize, Color)> Plot for F {
-    fn plot(&mut self, x: usize, y: usize, c: Color) {
-        self(x, y, c)
+pub struct Raster<Shade, Test, Output> {
+    pub shade: Shade,
+    pub test: Test,
+    pub output: Output,
+}
+
+
+impl<VA, FA, Shade, Test, Output> RasterOps<VA, FA>
+for Raster<Shade, Test, Output>
+where
+    VA: Copy,
+    Shade: FnMut(Fragment<VA>, FA) -> Color,
+    Test: FnMut(Fragment<VA>) -> bool,
+    Output: FnMut(usize, usize, Color),
+{
+    fn shade(&mut self, frag: Fragment<VA>, uniform: FA) -> Color {
+        (self.shade)(frag, uniform)
+    }
+    fn test(&mut self, frag: Fragment<VA>) -> bool {
+        (self.test)(frag)
+    }
+    fn output(&mut self, x: usize, y: usize, c: Color) {
+        (self.output)(x, y, c);
     }
 }
+
 
 #[derive(Default, Clone)]
 pub struct Obj<VA, FA> {
@@ -40,18 +70,77 @@ pub struct Scene<VA, FA> {
     pub camera: Mat4,
 }
 
+#[derive(Clone)]
+pub struct Buffer<T, B: DerefMut<Target=[T]> = Vec<T>> {
+    pub width: usize,
+    pub height: usize,
+    pub data: B,
+}
+impl<B: DerefMut<Target=[u8]>> Buffer<u8, B> {
+    pub fn plot(&mut self, x: usize, y: usize, c: Color) {
+        let idx = 4 * (self.width * y + x);
+        let [_, r, g, b] = c.to_argb();
+        self.data[idx + 0] = b;
+        self.data[idx + 1] = g;
+        self.data[idx + 2] = r;
+    }
+}
+impl<T> Buffer<T, Vec<T>> {
+    pub fn new(width: usize, height: usize, init: T) -> Self
+    where T: Clone {
+        Self {
+            width, height,
+            data: vec![init; width * height],
+        }
+    }
+}
+impl<'a, T> Buffer<T, &'a mut [T]> {
+    pub fn borrow(width: usize, data: &'a mut [T]) -> Self {
+        let height = data.len() / width;
+        assert_eq!(data.len(), width * height);
+        Self { width, height, data }
+    }
+}
+
+pub struct DepthBuf {
+    buf: Buffer<f32>,
+}
+impl DepthBuf {
+    pub fn new(width: usize, height: usize) -> Self {
+        Self {
+            buf: Buffer {
+                width, height,
+                data: vec![f32::INFINITY; width * height],
+            }
+        }
+    }
+
+    pub fn test<V: Copy>(&mut self, frag: Fragment<V>) -> bool {
+        let Vec4 { x, y, z, .. } = frag.coord;
+        let d = &mut self.buf.data[y as usize * self.buf.width + x as usize];
+        if *d > z { *d = z; true } else { false }
+    }
+
+    pub fn clear(&mut self) {
+        let buf = &mut self.buf;
+        buf.data.clear();
+        buf.data.resize(buf.width * buf.height, f32::INFINITY);
+    }
+}
+
 #[derive(Default, Clone)]
 pub struct Renderer {
     pub modelview: Mat4,
     pub projection: Mat4,
     pub viewport: Mat4,
-    pub stats: Stats,
     pub options: Options,
+    pub stats: Stats,
 }
 
 #[derive(Copy, Clone, Default)]
 pub struct Options {
     pub perspective_correct: bool,
+    pub depth_sort: bool,
 }
 
 impl Renderer {
@@ -59,34 +148,30 @@ impl Renderer {
         Self::default()
     }
 
-    pub fn render_scene<VA, FA, Shade>(
+    pub fn render_scene<VA, FA>(
         &mut self,
         scene: &Scene<VA, FA>,
-        shade: &Shade,
-        plot: &mut impl Plot
+        raster: &mut impl RasterOps<VA, FA>,
     ) -> Stats
     where
         VA: Copy + Linear<f32>,
         FA: Copy,
-        Shade: Fn(Fragment<VA>, FA) -> Color,
     {
         for obj in &scene.objects {
             self.modelview = &obj.tf * &scene.camera;
-            self.render(&obj.mesh, shade, plot);
+            self.render(&obj.mesh, raster);
         }
         self.stats
     }
 
-    pub fn render<VA, FA, Shade>(
+    pub fn render<VA, FA>(
         &mut self,
         mesh: &Mesh<VA, FA>,
-        shade: &Shade,
-        plot: &mut impl Plot
+        raster: &mut impl RasterOps<VA, FA>,
     ) -> Stats
     where
         VA: Copy + Linear<f32>,
         FA: Copy,
-        Shade: Fn(Fragment<VA>, FA) -> Color,
     {
         let clock = Instant::now();
 
@@ -112,11 +197,13 @@ impl Renderer {
                 self.stats.faces_out += mesh.faces.len();
                 self.stats.objs_out += 1;
 
-                Self::z_sort(&mut mesh);
+                if self.options.depth_sort {
+                    Self::depth_sort(&mut mesh);
+                }
 
                 self.perspective_divide(&mut mesh);
 
-                self.rasterize(mesh, shade, plot);
+                self.rasterize(mesh, raster);
             }
         }
 
@@ -125,7 +212,7 @@ impl Renderer {
     }
 
     // TODO Replace with z-buffering (or s-buffering!)
-    fn z_sort<VA, FA: Copy>(mesh: &mut Mesh<VA, FA>) {
+    fn depth_sort<VA, FA: Copy>(mesh: &mut Mesh<VA, FA>) {
         let (faces, attrs) = {
             let Mesh { verts, faces, face_attrs, .. } = &*mesh;
 
@@ -161,15 +248,13 @@ impl Renderer {
         }
     }
 
-    pub fn rasterize<VA, FA, Shade>(
+    pub fn rasterize<VA, FA>(
         &mut self,
         mut mesh: Mesh<VA, FA>,
-        shade: &Shade,
-        plot: &mut impl Plot
+        raster: &mut impl RasterOps<VA, FA>,
     ) where
         VA: Copy + Linear<f32>,
         FA: Copy,
-        Shade: Fn(Fragment<VA>, FA) -> Color,
     {
         let Mesh { faces, verts, vertex_attrs, face_attrs, .. } = &mut mesh;
 
@@ -184,11 +269,13 @@ impl Renderer {
             let fa = face_attrs[i];
 
             tri_fill(frags[0], frags[1], frags[2], |frag: Fragment<_>| {
-                plot.plot(
-                    frag.coord.x as usize,
-                    frag.coord.y as usize,
-                    shade(frag, fa)
-                );
+                if raster.test(frag) {
+                    let color = raster.shade(frag, fa);
+                    let x = frag.coord.x as usize;
+                    let y = frag.coord.y as usize;
+                    // TODO let color = raster.blend(x, y, color);
+                    raster.output(x, y, color);
+                }
                 self.stats.pixels += 1;
             });
         }

--- a/lib/render/src/tex.rs
+++ b/lib/render/src/tex.rs
@@ -1,5 +1,6 @@
 use math::Linear;
 use crate::color::Color;
+use crate::Buffer;
 
 #[derive(Copy, Clone, Debug)]
 pub struct TexCoord {
@@ -31,17 +32,14 @@ impl Linear<f32> for TexCoord {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Texture {
-    width: usize,
-    height: usize,
-    fwidth: f32,
-    fheight: f32,
-    data: Vec<Color>,
+    width: f32,
+    height: f32,
+    buf: Buffer<Color>,
 }
 
 impl Texture {
-
     pub fn new(width: usize, data: &[Color]) -> Texture {
         assert!(width.is_power_of_two());
         let height = data.len() / width;
@@ -49,10 +47,12 @@ impl Texture {
         assert_eq!(height * width, data.len());
 
         Texture {
-            width, height,
-            fwidth: width as f32,
-            fheight: height as f32,
-            data: data.to_vec(),
+            width: width as f32,
+            height: height as f32,
+            buf: Buffer {
+                width, height,
+                data: data.to_vec(),
+            }
         }
     }
 
@@ -61,18 +61,18 @@ impl Texture {
         assert!(height.is_power_of_two());
 
         Texture {
-            width, height,
-            fwidth: width as f32,
-            fheight: height as f32,
-            data: vec![color; width * height],
+            width: width as f32,
+            height: height as f32,
+            buf:  Buffer::new(width, height, color),
         }
     }
 
     pub fn sample(&self, TexCoord { u, v, w }: TexCoord) -> Color {
+        let buf = &self.buf;
         let w = 1.0 / w;
-        let u = (self.fwidth * u * w) as usize & (self.width - 1);
-        let v = (self.fheight * v * w) as usize & (self.height - 1);
+        let u = (self.width * u * w) as usize & (buf.width - 1);
+        let v = (self.height * v * w) as usize & (buf.height - 1);
 
-        self.data[self.width * v + u]
+        buf.data[buf.width * v + u]
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -34,8 +34,11 @@ where VA: Copy + Linear<f32>, FA: Copy + Debug
 
     let stats = rdr.render(
         &mesh,
-        &|_, _| BLACK,
-        &mut |x, y, _| buf[10 * y + x] = '#'
+        &mut Raster {
+            shade: &|_, _| BLACK,
+            test: |_| true,
+            output: &mut |x, y, _| buf[10 * y + x] = '#'
+        }
     );
     eprintln!("Stats: {}", stats);
     buf.iter().collect()
@@ -52,8 +55,11 @@ where VA: Copy + Linear<f32>, FA: Copy
 
     let stats = rdr.render_scene(
         &scene,
-        &|_, _| BLACK,
-        &mut |_, _, _| ()
+        &mut Raster {
+            shade: |_, _| BLACK,
+            test: |_| true,
+            output: |_, _, _| ()
+        }
     );
     eprintln!("Stats: {}", stats);
     stats


### PR DESCRIPTION
Add a new "fragment test" callback to Renderer methods. Pass the callbacks
wrapped in a struct rather than as individual arguments in order to reduce
clutter.