### PR TITLE
Clean up Vary API

### DIFF
--- a/core/src/math/space.rs
+++ b/core/src/math/space.rs
@@ -116,19 +116,13 @@ where
         Iter { val: self, step, n }
     }
 
+    fn dv_dt(&self, other: &Self, recip_dt: f32) -> Self::Diff {
+        other.sub(self).mul(recip_dt)
+    }
+
     /// Adds `delta` to `self`.
     #[inline]
     fn step(&self, delta: &Self::Diff) -> Self {
         self.add(delta)
-    }
-
-    /// Subtracts `other` from `self`.
-    fn diff(&self, other: &Self) -> Self::Diff {
-        self.sub(other)
-    }
-
-    /// Multiplies `diff` by `s`.
-    fn scale(diff: &Self::Diff, s: f32) -> Self::Diff {
-        diff.mul(s)
     }
 }


### PR DESCRIPTION
Replace the smelly diff and scale methods with a single new method dv_dt that handles all the use cases of the removed methods, also simplifying calling code.