### PR TITLE
Change generic parameters of VecN and vecN

### DIFF
--- a/core/src/geom/mesh.rs
+++ b/core/src/geom/mesh.rs
@@ -9,7 +9,7 @@ use alloc::{vec, vec::Vec};
 
 use crate::math::{
     mat::{Mat4x4, RealToReal},
-    space::{Linear, Real},
+    space::Linear,
     vec::Vec3,
 };
 use crate::render::Model;
@@ -17,7 +17,7 @@ use crate::render::Model;
 use super::{vertex, Normal3, Tri};
 
 /// Convenience type alias for a mesh vertex.
-pub type Vertex<A, Sp = Real<3, Model>> = super::Vertex<Vec3<Sp>, A>;
+pub type Vertex<A, B = Model> = super::Vertex<Vec3<B>, A>;
 
 /// A triangle mesh.
 ///
@@ -27,25 +27,25 @@ pub type Vertex<A, Sp = Real<3, Model>> = super::Vertex<Vec3<Sp>, A>;
 /// with 8 vertices and 12 faces. By using many faces, complex curved shapes
 /// can be approximated.
 #[derive(Clone)]
-pub struct Mesh<Attrib, Space = Real<3, Model>> {
+pub struct Mesh<Attrib, Basis = Model> {
     /// The faces of the mesh, with each face a triplet of indices
     /// to the `verts` vector. Several faces can share a vertex.
     pub faces: Vec<Tri<usize>>,
     /// The vertices of the mesh.
-    pub verts: Vec<Vertex<Attrib, Space>>,
+    pub verts: Vec<Vertex<Attrib, Basis>>,
 }
 
 /// A builder type for creating meshes.
 #[derive(Clone)]
-pub struct Builder<Attrib = (), Space = Real<3, Model>> {
-    pub mesh: Mesh<Attrib, Space>,
+pub struct Builder<Attrib = (), Basis = Model> {
+    pub mesh: Mesh<Attrib, Basis>,
 }
 
 //
 // Inherent impls
 //
 
-impl<A, S> Mesh<A, S> {
+impl<A, B> Mesh<A, B> {
     /// Creates a new triangle mesh with the given faces and vertices.
     ///
     /// Each face in `faces` is a triplet of indices, referring to
@@ -71,14 +71,14 @@ impl<A, S> Mesh<A, S> {
     /// ];
     ///
     /// // Create a mesh with a tetrahedral shape
-    /// let tetra = Mesh::new(faces, verts);
+    /// let tetra: Mesh<()> = Mesh::new(faces, verts);
     /// ```
     /// # Panics
     /// If any of the vertex indices in `faces` ≥ `verts.len()`.
     pub fn new<F, V>(faces: F, verts: V) -> Self
     where
         F: IntoIterator<Item = Tri<usize>>,
-        V: IntoIterator<Item = Vertex<A, S>>,
+        V: IntoIterator<Item = Vertex<A, B>>,
     {
         let faces: Vec<_> = faces.into_iter().collect();
         let verts: Vec<_> = verts.into_iter().collect();
@@ -265,7 +265,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn mesh_new_panics_if_vertex_index_oob() {
-        _ = Mesh::new(
+        let _: Mesh<()> = Mesh::new(
             [Tri([0, 1, 2]), Tri([1, 2, 3])],
             [
                 vertex(vec3(0.0, 0.0, 0.0), ()),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -61,10 +61,7 @@ pub mod prelude {
         rand::Distrib,
         space::{Affine, Linear},
         vary::{lerp, Vary},
-        vec::{
-            splat, vec2, vec3, vec4, Vec2, Vec2i, Vec2u, Vec3, Vec3i, Vec4,
-            Vec4i, Vector,
-        },
+        vec::{splat, vec2, vec3, Vec2, Vec2i, Vec2u, Vec3, Vec3i, Vector},
     };
 
     pub use crate::geom::{vertex, Mesh, Normal2, Normal3, Tri, Vertex};

--- a/core/src/math.rs
+++ b/core/src/math.rs
@@ -22,8 +22,8 @@ pub use approx::ApproxEq;
 pub use mat::{Mat3x3, Mat4x4, Matrix};
 pub use space::{Affine, Linear};
 pub use vary::{lerp, Vary};
-pub use vec::{vec2, vec3, vec4};
-pub use vec::{Vec2, Vec2i, Vec3, Vec3i, Vec4, Vec4i, Vector};
+pub use vec::{vec2, vec3};
+pub use vec::{Vec2, Vec2i, Vec3, Vec3i, Vector};
 
 pub mod angle;
 pub mod approx;

--- a/core/src/math/mat.rs
+++ b/core/src/math/mat.rs
@@ -7,9 +7,10 @@ use core::fmt::{self, Debug, Formatter};
 use core::marker::PhantomData;
 use core::ops::Range;
 
-use crate::math::space::{Proj4, Real};
-use crate::math::vec::{Vec2u, Vec3, Vec4, Vector};
 use crate::render::{NdcToScreen, ViewToProj};
+
+use super::space::{Proj4, Real};
+use super::vec::{ProjVec4, Vec2u, Vec3, Vector};
 
 /// A linear transform from one space (or basis) to another.
 ///
@@ -195,7 +196,7 @@ impl<Src, Dst> Mat4x4<RealToReal<3, Src, Dst>> {
     ///         \ ·  ·  M33 / \  1 /
     /// ```
     #[must_use]
-    pub fn apply(&self, v: &Vec3<Real<3, Src>>) -> Vec3<Real<3, Dst>> {
+    pub fn apply(&self, v: &Vec3<Src>) -> Vec3<Dst> {
         let v = Vector::from([v.x(), v.y(), v.z(), 1.0]);
         let x = self.row_vec(0).dot(&v);
         let y = self.row_vec(1).dot(&v);
@@ -352,7 +353,7 @@ impl<B> Mat4x4<RealToProj<B>> {
     ///         \ ·  ·  M33 / \  1 /
     /// ```
     #[must_use]
-    pub fn apply(&self, v: &Vec3<Real<3, B>>) -> Vec4<Proj4> {
+    pub fn apply(&self, v: &Vec3<B>) -> ProjVec4 {
         let v = Vector::from([v.x(), v.y(), v.z(), 1.0]);
         [
             self.row_vec(0).dot(&v),
@@ -647,7 +648,7 @@ mod tests {
     #[test]
     fn scaling() {
         let m = scale(vec3(1.0, -2.0, 3.0));
-        let v = vec3(0.0, 4.0, -3.0).to();
+        let v = vec3(0.0, 4.0, -3.0);
 
         assert_eq!(m.apply(&v), vec3(0.0, -8.0, -9.0));
     }
@@ -655,7 +656,7 @@ mod tests {
     #[test]
     fn translation() {
         let m = translate(vec3(1.0, 2.0, 3.0));
-        let v = vec3(0.0, 5.0, -3.0).to();
+        let v = vec3(0.0, 5.0, -3.0);
 
         assert_eq!(m.apply(&v), vec3(1.0, 7.0, 0.0));
     }
@@ -721,8 +722,8 @@ mod tests {
                 .to();
         let m_inv: Mat4x4<RealToReal<3, Basis2, Basis1>> = m.inverse();
 
-        let v1: Vec3<Real<3, Basis1>> = vec3(1.0, -2.0, 3.0).to();
-        let v2: Vec3<Real<3, Basis2>> = vec3(2.0, 0.0, -2.0).to();
+        let v1: Vec3<Basis1> = vec3(1.0, -2.0, 3.0);
+        let v2: Vec3<Basis2> = vec3(2.0, 0.0, -2.0);
 
         assert_eq!(m_inv.apply(&m.apply(&v1)), v1);
         assert_eq!(m.apply(&m_inv.apply(&v2)), v2);
@@ -746,10 +747,10 @@ mod tests {
 
         let m = perspective(0.8, 2.0, 0.1..100.0);
 
-        let lbn = m.apply(&left_bot_near.to());
+        let lbn = m.apply(&left_bot_near);
         assert_approx_eq!(lbn / lbn.w(), [-1.0, -1.0, -1.0, 1.0].into());
 
-        let rtf = m.apply(&right_top_far.to());
+        let rtf = m.apply(&right_top_far);
         assert_approx_eq!(rtf / rtf.w(), splat(1.0));
     }
 }

--- a/core/src/math/rand.rs
+++ b/core/src/math/rand.rs
@@ -326,7 +326,9 @@ mod tests {
     #[test]
     fn uniform_vec3() {
         let gen = Xorshift64::default();
-        let mut d = Uniform(gen, vec3(-2.0, 0.0, -1.0)..vec3(1.0, 2.0, 3.0));
+        let rg: Range<Vec3> = vec3(-2.0, 0.0, -1.0)..vec3(1.0, 2.0, 3.0);
+        let mut d = Uniform(gen, rg);
+
         let mut sum = vec3(0.0, 0.0, 0.0);
         for v in d.iter().take(COUNT) {
             assert!(-2.0 <= v.x() && v.x() < 1.0);

--- a/core/src/math/spline.rs
+++ b/core/src/math/spline.rs
@@ -194,11 +194,10 @@ impl<T: Linear<Scalar = f32> + Copy> BezierSpline<T> {
     ///
     /// # Examples
     /// ```
-    /// # use retrofire_core::math::spline::BezierSpline;
-    /// # use retrofire_core::math::vec2;
-    /// let curve = BezierSpline::new(
-    ///     &[vec2(0.0, 0.0), vec2(0.0, 1.0), vec2(1.0, 1.0), vec2(1.0, 0.0)
-    /// ]);
+    /// # use retrofire_core::math::{spline::BezierSpline, vec::{vec2, Vec2}};
+    /// let curve = BezierSpline::<Vec2>::new(
+    ///     &[vec2(0.0, 0.0), vec2(0.0, 1.0), vec2(1.0, 1.0), vec2(1.0, 0.0)]
+    /// );
     /// let approx = curve.approximate(|err| err.len_sqr() < 0.01*0.01);
     /// assert_eq!(approx.len(), 17);
     /// ```
@@ -299,7 +298,8 @@ mod tests {
     #[test]
     fn bezier_spline_eval_2d() {
         let b = CubicBezier(
-            [[0.0, 0.0], [0.0, 2.0], [1.0, -1.0], [1.0, 1.0]].map(Vec2::from),
+            [[0.0, 0.0], [0.0, 2.0], [1.0, -1.0], [1.0, 1.0]]
+                .map(Vec2::<()>::from),
         );
 
         assert_eq!(b.eval(-1.0), vec2(0.0, 0.0));
@@ -327,7 +327,8 @@ mod tests {
     #[test]
     fn bezier_spline_tangent_2d() {
         let b = CubicBezier(
-            [[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]].map(Vec2::from),
+            [[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]]
+                .map(Vec2::<()>::from),
         );
 
         assert_eq!(b.tangent(-1.0), vec2(0.0, 3.0),);

--- a/core/src/render.rs
+++ b/core/src/render.rs
@@ -17,7 +17,6 @@ use target::Target;
 
 use crate::geom::{Tri, Vertex};
 use crate::math::mat::{RealToProj, RealToReal};
-use crate::math::space::Real;
 use crate::math::{vec3, Mat4x4, Vary, Vec3};
 
 pub mod cam;
@@ -123,7 +122,7 @@ pub fn render<Vtx: Clone, Var: Vary, Uni: Copy, Shd>(
             let pos = vec3(x, y, 1.0).z_div(w);
             Vertex {
                 // Viewport transform
-                pos: to_screen.apply(&pos.to()),
+                pos: to_screen.apply(&pos),
                 // Perspective correction
                 attrib: v.attrib.z_div(w),
             }
@@ -161,7 +160,7 @@ fn depth_sort<A>(tris: &mut [Tri<ClipVert<A>>], d: DepthSort) {
     });
 }
 
-fn is_backface<V>(vs: &[Vertex<Vec3<Real<3, Screen>>, V>]) -> bool {
+fn is_backface<V>(vs: &[Vertex<Vec3<Screen>, V>]) -> bool {
     let v = vs[1].pos - vs[0].pos;
     let u = vs[2].pos - vs[0].pos;
     v[0] * u[1] - v[1] * u[0] > 0.0

--- a/core/src/render/clip.rs
+++ b/core/src/render/clip.rs
@@ -17,9 +17,8 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use crate::geom::{Plane, Tri, Vertex};
-use crate::math::space::Proj4;
 use crate::math::vary::Vary;
-use crate::math::vec::{Vec3, Vec4};
+use crate::math::vec::{ProjVec4, Vec3};
 
 use view_frustum::{outcode, status};
 
@@ -52,7 +51,7 @@ pub trait Clip {
 }
 
 /// A vector in clip space.
-pub type ClipVec = Vec4<Proj4>;
+pub type ClipVec = ProjVec4;
 
 /// A plane in clip space.
 pub type ClipPlane = Plane<ClipVec>;

--- a/core/src/render/raster.rs
+++ b/core/src/render/raster.rs
@@ -15,7 +15,6 @@ use core::fmt::Debug;
 use core::ops::Range;
 
 use crate::geom::Vertex;
-use crate::math::space::Real;
 use crate::math::{Vary, Vec3};
 
 use super::Screen;
@@ -49,7 +48,7 @@ pub struct ScanlineIter<V: Vary> {
 
 /// Vector in screen space.
 /// `x` and `y` are viewport pixel coordinates, `z` is depth.
-pub type ScreenVec = Vec3<Real<3, Screen>>;
+pub type ScreenVec = Vec3<Screen>;
 
 /// Values to interpolate across a rasterized primitive.
 pub type Varyings<V> = (ScreenVec, V);
@@ -262,7 +261,7 @@ mod tests {
             vec3(14.0, 10.0, 0.0),
             vec3(20.0, 3.0, 0.0),
         ]
-        .map(|pos| vertex(pos.to(), 0.0));
+        .map(|pos| vertex(pos, 0.0));
 
         let expected = r"
 00000001110000000000
@@ -301,11 +300,11 @@ mod tests {
     fn gradient() {
         use core::fmt::Write;
         let verts = [
-            vec3(15.0, 2.0, 0.0),
+            vec3::<_, ()>(15.0, 2.0, 0.0),
             vec3(2.0, 8.0, 1.0),
             vec3(26.0, 14.0, 0.5),
         ]
-        .map(|pos| vertex(vec3(pos.x(), pos.y(), 1.0).to(), pos.z()));
+        .map(|pos| vertex(vec3(pos.x(), pos.y(), 1.0), pos.z()));
 
         let expected = r"
               0
@@ -342,8 +341,8 @@ mod tests {
             y: 42,
             xs: 8..16,
             vs: Vary::vary_to(
-                (vec3(8.0, 42.0, 1.0 / w0).to(), 3.0.z_div(w0)),
-                (vec3(16.0, 42.0, 1.0 / w1).to(), 5.0.z_div(w1)),
+                (vec3(8.0, 42.0, 1.0 / w0), 3.0.z_div(w0)),
+                (vec3(16.0, 42.0, 1.0 / w1), 5.0.z_div(w1)),
                 8,
             ),
         };
@@ -360,7 +359,7 @@ mod tests {
         let mut x = 8.0;
 
         for ((Frag { pos, var }, z), v) in sl.fragments().zip(zs).zip(vars) {
-            assert_approx_eq!(pos, vec3(x, 42.0, z.recip()).to());
+            assert_approx_eq!(pos, vec3(x, 42.0, z.recip()));
             assert_approx_eq!(var, v);
 
             x += 1.0;

--- a/core/src/render/shader.rs
+++ b/core/src/render/shader.rs
@@ -80,6 +80,21 @@ pub struct Shader<Vs, Fs> {
     pub fragment_shader: Fs,
 }
 
+impl<Vs, Fs> Shader<Vs, Fs> {
+    /// Returns a new `Shader` with `vs` as the vertex shader
+    /// and `fs` as the fragment shader.
+    pub const fn new<In, Uni, Pos, Attr>(vs: Vs, fs: Fs) -> Self
+    where
+        Vs: VertexShader<In, Uni, Output = Vertex<Pos, Attr>>,
+        Fs: FragmentShader<Frag<Attr>>,
+    {
+        Self {
+            vertex_shader: vs,
+            fragment_shader: fs,
+        }
+    }
+}
+
 impl<In, Vs, Fs, Uni> VertexShader<In, Uni> for Shader<Vs, Fs>
 where
     Vs: VertexShader<In, Uni>,
@@ -97,20 +112,5 @@ where
 {
     fn shade_fragment(&self, frag: F) -> Option<Color4> {
         self.fragment_shader.shade_fragment(frag)
-    }
-}
-
-impl<Vs, Fs> Shader<Vs, Fs> {
-    /// Returns a new `Shader` with `vs` as the vertex shader
-    /// and `fs` as the fragment shader.
-    pub const fn new<In, Uni, Pos, Attr>(vs: Vs, fs: Fs) -> Self
-    where
-        Vs: VertexShader<In, Uni, Output = Vertex<Pos, Attr>>,
-        Fs: FragmentShader<Frag<Attr>>,
-    {
-        Self {
-            vertex_shader: vs,
-            fragment_shader: fs,
-        }
     }
 }

--- a/core/src/render/tex.rs
+++ b/core/src/render/tex.rs
@@ -1,6 +1,5 @@
 //! Textures and texture samplers.
 
-use crate::math::space::Real;
 use crate::math::vec::{Vec2, Vector};
 use crate::util::buf::{AsSlice2, Buf2, Slice2};
 
@@ -12,7 +11,7 @@ pub struct Tex;
 /// in range (0, 0)..(w, h) for some texture with dimensions w and h, or
 /// relative, in range (0, 0)..(1, 1), in which case they are independent
 /// of the actual dimensions of the texture.
-pub type TexCoord = Vec2<Real<2, Tex>>;
+pub type TexCoord = Vec2<Tex>;
 
 impl TexCoord {
     /// Returns the u (horizontal) component of `self`.

--- a/demos/src/bin/crates.rs
+++ b/demos/src/bin/crates.rs
@@ -114,7 +114,7 @@ fn floor() -> Mesh<Color3f> {
 
             let pos = vec3(i as f32, -1.0, j as f32);
             let col = if even_odd { gray(0.2) } else { gray(0.9) };
-            bld.push_vert(pos.to(), col);
+            bld.push_vert(pos, col);
 
             if j > -size && i > -size {
                 let w = size * 2 + 1;

--- a/demos/src/bin/square.rs
+++ b/demos/src/bin/square.rs
@@ -2,17 +2,16 @@ use std::ops::ControlFlow::*;
 
 use re::prelude::*;
 
-use re::math::space::Real;
 use re::render::tex::{uv, SamplerClamp, TexCoord, Texture};
 use re::render::{render, Model, ModelToProj};
 use re_front::minifb::Window;
 
 fn main() {
-    let verts: [Vertex<Vec3<Real<3, Model>>, TexCoord>; 4] = [
-        vertex(vec3(-1.0, -1.0, 0.0).to(), uv(0.0, 0.0)),
-        vertex(vec3(-1.0, 1.0, 0.0).to(), uv(0.0, 1.0)),
-        vertex(vec3(1.0, -1.0, 0.0).to(), uv(1.0, 0.0)),
-        vertex(vec3(1.0, 1.0, 0.0).to(), uv(1.0, 1.0)),
+    let verts: [Vertex<Vec3<Model>, TexCoord>; 4] = [
+        vertex(vec3(-1.0, -1.0, 0.0), uv(0.0, 0.0)),
+        vertex(vec3(-1.0, 1.0, 0.0), uv(0.0, 1.0)),
+        vertex(vec3(1.0, -1.0, 0.0), uv(1.0, 0.0)),
+        vertex(vec3(1.0, 1.0, 0.0), uv(1.0, 1.0)),
     ];
 
     let mut win = Window::builder()

--- a/demos/wasm/src/triangle.rs
+++ b/demos/wasm/src/triangle.rs
@@ -24,9 +24,9 @@ pub fn start() {
     win.ctx.color_clear = Some(rgba(0, 0, 0, 0x80));
 
     let vs = [
-        vertex(vec3(-2.0, 1.0, 0.0).to(), rgba(1.0, 0.2, 0.1, 0.9)),
-        vertex(vec3(2.0, 2.0, 0.0).to(), rgba(0.2, 0.9, 0.1, 0.8)),
-        vertex(vec3(0.0, -2.0, 0.0).to(), rgba(0.3, 0.4, 1.0, 1.0)),
+        vertex(vec3(-2.0, 1.0, 0.0), rgba(1.0, 0.2, 0.1, 0.9)),
+        vertex(vec3(2.0, 2.0, 0.0), rgba(0.2, 0.9, 0.1, 0.8)),
+        vertex(vec3(0.0, -2.0, 0.0), rgba(0.3, 0.4, 1.0, 1.0)),
     ];
 
     let proj = perspective(1.0, 4.0 / 3.0, 0.1..1000.0);

--- a/geom/src/io.rs
+++ b/geom/src/io.rs
@@ -51,10 +51,7 @@ use std::{
 };
 
 use re::geom::{mesh::Builder, vertex, Mesh, Normal3, Tri};
-use re::math::{
-    space::Real,
-    vec::{vec3, Vec3, Vector},
-};
+use re::math::vec::{vec3, Vec3, Vector};
 use re::render::{
     tex::{uv, TexCoord},
     Model,
@@ -209,11 +206,11 @@ fn parse_texcoord<'a>(
 
 fn parse_vector<'a>(
     i: &mut impl Iterator<Item = &'a str>,
-) -> Result<Vec3<Real<3, Model>>> {
+) -> Result<Vec3<Model>> {
     let x = next(i)?.parse()?;
     let y = next(i)?.parse()?;
     let z = next(i)?.parse()?;
-    Ok(vec3(x, y, z).to())
+    Ok(vec3(x, y, z))
 }
 
 fn parse_normal<'a>(i: &mut impl Iterator<Item = &'a str>) -> Result<Normal3> {
@@ -315,7 +312,7 @@ v 1.0 2.0      0.0";
         let mesh = parse_obj(input).unwrap().build();
 
         assert_eq!(mesh.faces, vec![Tri([0, 1, 3]), Tri([3, 0, 2])]);
-        assert_eq!(mesh.verts[3].pos, vec3(1.0, 2.0, 0.0).to());
+        assert_eq!(mesh.verts[3].pos, vec3(1.0, 2.0, 0.0));
     }
 
     #[test]

--- a/geom/src/solids.rs
+++ b/geom/src/solids.rs
@@ -174,7 +174,7 @@ impl Tetrahedron {
         for (i, vs) in Self::FACES.into_iter().enumerate() {
             b.push_face(3 * i, 3 * i + 1, 3 * i + 2);
             for v in vs {
-                b.push_vert(coords[v].to(), norms[i]);
+                b.push_vert(coords[v], norms[i]);
             }
         }
         b.build()
@@ -377,7 +377,7 @@ impl Dodecahedron {
             b.push_face(i5, i5 + 2, i5 + 3);
             b.push_face(i5, i5 + 3, i5 + 4);
             for &j in face {
-                b.push_vert(Self::COORDS[j].to().normalize(), n);
+                b.push_vert(Self::COORDS[j].normalize(), n);
             }
         }
         b.build()
@@ -422,7 +422,7 @@ impl Icosahedron {
             let n = Self::NORMALS[i].normalize();
             b.push_face(3 * i, 3 * i + 1, 3 * i + 2);
             for vi in *vs {
-                b.push_vert(Self::COORDS[vi].to().normalize(), n);
+                b.push_vert(Self::COORDS[vi].normalize(), n);
             }
         }
         b.build()


### PR DESCRIPTION
* Change VecN type aliases to always be in Real<N, B>, generic over B. This better matches their intended semantics as specifically Cartesian vectors. For example, SphericalVec and Vec3 are now always distinct types.

* Change vecN functions to be generic over B, matching their respective VecN. This removes the need of most uses of .to(), at the expense of sometimes being unable to infer B.

* Turn generic Vec4 to ProjVec4 specifically, with little need for Cartesian 4-vectors at least for now. Remove vec4 functions as unneeded.