### PR TITLE
Replace impl that triggered a lint on Rust 1.80

### DIFF
--- a/core/src/math/vec.rs
+++ b/core/src/math/vec.rs
@@ -564,10 +564,31 @@ where
     }
 }
 
-/// The scalar * vector operator.
-impl<R, Sp> Mul<Vector<R, Sp>> for <Vector<R, Sp> as Linear>::Scalar
+impl<R, Sp> Mul<Vector<R, Sp>> for f32
 where
-    Vector<R, Sp>: Linear,
+    Vector<R, Sp>: Linear<Scalar = f32>,
+{
+    type Output = Vector<R, Sp>;
+
+    #[inline]
+    fn mul(self, rhs: Vector<R, Sp>) -> Self::Output {
+        rhs * self
+    }
+}
+impl<R, Sp> Mul<Vector<R, Sp>> for i32
+where
+    Vector<R, Sp>: Linear<Scalar = i32>,
+{
+    type Output = Vector<R, Sp>;
+
+    #[inline]
+    fn mul(self, rhs: Vector<R, Sp>) -> Self::Output {
+        rhs * self
+    }
+}
+impl<R, Sp> Mul<Vector<R, Sp>> for u32
+where
+    Vector<R, Sp>: Linear<Scalar = u32>,
 {
     type Output = Vector<R, Sp>;
 


### PR DESCRIPTION
The generic Mul<Vector> for Scalar impl violated orphan rules, but used to
be accepted by rustc due to a bug. Replace the impl with separate concrete
impls for f32, i32, and u32.

See https://github.com/rust-lang/rust/issues/124559 for more info.