### PR TITLE
Make buf::inner public but #[doc(hidden)]

### DIFF
--- a/core/src/util/buf.rs
+++ b/core/src/util/buf.rs
@@ -278,7 +278,8 @@ impl<'a, T> DerefMut for MutSlice2<'a, T> {
     }
 }
 
-mod inner {
+#[doc(hidden)]
+pub mod inner {
     use core::fmt::Formatter;
     use core::marker::PhantomData;
     use core::ops::{Deref, DerefMut, Index, IndexMut, Range};


### PR DESCRIPTION
Needed to make the Inner interface visible in docs.