### PR TITLE
Add segments parameter to Cylinder, Cone, and Capsule

### DIFF
--- a/demos/src/bin/solids.rs
+++ b/demos/src/bin/solids.rs
@@ -110,8 +110,10 @@ fn main() {
             .to::<ModelToWorld>()
             .then(&cam.world_to_project());
 
+        let object = &objects[carousel.idx % objects.len()];
+
         Batch::new()
-            .mesh(&objects[carousel.idx % objects.len()])
+            .mesh(object)
             .uniform((&model_view_project, &spin))
             .shader(shader)
             .viewport(cam.viewport)
@@ -130,6 +132,7 @@ fn objects(res: u32) -> [Mesh<Normal3>; 13] {
     let sectors = 2 * res;
 
     let cap_segments = res;
+    let body_segments = res;
 
     let major_sectors = 3 * res;
     let minor_sectors = 2 * res;
@@ -143,11 +146,11 @@ fn objects(res: u32) -> [Mesh<Normal3>; 13] {
 
         // Surfaces of revolution
         lathe(sectors),
-        Sphere { sectors, segments, radius: 1.0, }.build(),
-        Cylinder { sectors, radius: 0.8, capped: true }.build(),
-        Cone { sectors, base_radius: 1.1, apex_radius: 0.3, capped: true, }.build(),
-        Capsule { sectors, cap_segments, radius: 0.5, }.build(),
-        Torus { major_radius: 0.9, minor_radius: 0.3, major_sectors, minor_sectors, }.build(),
+        Sphere { radius: 1.0, sectors, segments, }.build(),
+        Cylinder { radius: 0.8, sectors, segments, capped: true }.build(),
+        Cone { base_radius: 1.1, apex_radius: 0.3, sectors, segments, capped: true }.build(),
+        Capsule { radius: 0.5, sectors, body_segments, cap_segments }.build(),
+        Torus { major_radius: 0.9, minor_radius: 0.3, major_sectors, minor_sectors }.build(),
 
         // Traditional demo models
         teapot(),
@@ -158,7 +161,7 @@ fn objects(res: u32) -> [Mesh<Normal3>; 13] {
 // Creates a Lathe mesh.
 fn lathe(secs: u32) -> Mesh<Normal3> {
     Lathe::new(
-        vec![
+        [
             vertex(pt2(0.75, -0.5), vec2(1.0, 1.0)),
             vertex(pt2(0.55, -0.25), vec2(1.0, 0.5)),
             vertex(pt2(0.5, 0.0), vec2(1.0, 0.0)),

--- a/geom/src/solids/lathe.rs
+++ b/geom/src/solids/lathe.rs
@@ -42,6 +42,7 @@ pub struct Torus {
 /// Right cylinder with regular *n*-gonal cross-section.
 pub struct Cylinder {
     pub sectors: u32,
+    pub segments: u32,
     pub capped: bool,
     pub radius: f32,
 }
@@ -49,6 +50,7 @@ pub struct Cylinder {
 /// TODO
 pub struct Cone {
     pub sectors: u32,
+    pub segments: u32,
     pub capped: bool,
     pub base_radius: f32,
     pub apex_radius: f32,
@@ -57,6 +59,7 @@ pub struct Cone {
 /// Cylinder with hemispherical caps.
 pub struct Capsule {
     pub sectors: u32,
+    pub body_segments: u32,
     pub cap_segments: u32,
     pub radius: f32,
 }
@@ -181,9 +184,11 @@ impl Torus {
 impl Cylinder {
     /// Builds the cylindrical mesh.
     pub fn build(self) -> Mesh<Normal3> {
-        let Self { sectors, capped, radius } = self;
+        #[rustfmt::skip]
+        let Self { sectors, segments, capped, radius } = self;
         Cone {
             sectors,
+            segments,
             capped,
             base_radius: radius,
             apex_radius: radius,
@@ -195,11 +200,18 @@ impl Cylinder {
 impl Cone {
     /// Builds the conical mesh.
     pub fn build(self) -> Mesh<Normal3> {
+        assert!(self.segments > 0, "segments cannot be zero");
+
         let base_pt = pt2(self.base_radius, -1.0);
         let apex_pt = pt2(self.apex_radius, 1.0);
+
         let n = apex_pt - base_pt;
         let n = vec2(n.y(), -n.x());
-        let pts = [vertex(base_pt, n), vertex(apex_pt, n)];
+
+        let pts = base_pt
+            .vary_to(apex_pt, self.segments)
+            .map(|pt| vertex(pt, n));
+
         Lathe::new(pts, self.sectors)
             .capped(self.capped)
             .build()
@@ -209,16 +221,18 @@ impl Cone {
 impl Capsule {
     /// Builds the capsule mesh.
     pub fn build(self) -> Mesh<Normal3> {
-        let Self { sectors, cap_segments, radius } = self;
+        #[rustfmt::skip]
+        let Self { sectors, body_segments, cap_segments, radius } = self;
+        assert!(body_segments > 0, "body segments cannot be zero");
+        assert!(cap_segments > 0, "cap segments cannot be zero");
 
-        // Bottom hemisphere
+        // Must be collected to allow rev()
         let bottom_pts: Vec<_> = degs(-90.0)
             .vary_to(degs(0.0), cap_segments)
             .map(|alt| polar(radius, alt).to_cart())
             .map(|v| vertex(pt2(0.0, -1.0) + v, v))
             .collect();
 
-        // Top hemisphere
         let top_pts = bottom_pts
             .iter()
             .map(|Vertex { pos, attrib: n }| {
@@ -226,6 +240,20 @@ impl Capsule {
             })
             .rev();
 
-        Lathe::new(bottom_pts.iter().copied().chain(top_pts), sectors).build()
+        let body_pts = pt2(radius, -1.0)
+            .vary_to(pt2(radius, 1.0), body_segments)
+            .map(|pt| vertex(pt, vec2(1.0, 0.0)))
+            .skip(1)
+            .take(body_segments as usize - 1);
+
+        Lathe::new(
+            bottom_pts
+                .iter()
+                .copied()
+                .chain(body_pts)
+                .chain(top_pts),
+            sectors,
+        )
+        .build()
     }
 }


### PR DESCRIPTION
Allow subdivision into several stacked vertical segments. Useful for approximating more complex shapes with nonlinear transforms.