### PR TITLE
Roll-up: add several new methods

### DIFF
--- a/core/src/geom.rs
+++ b/core/src/geom.rs
@@ -137,6 +137,17 @@ impl<P: Affine, A> Tri<Vertex<P, A>> {
         let [a, b, c] = &self.0;
         [b.pos.sub(&a.pos), c.pos.sub(&a.pos)]
     }
+
+    /// Returns the geometric center, or "balance point", of `self`.
+    ///
+    /// The centroid is simply the average of the three vertex positions.
+    pub fn centroid(&self) -> P
+    where
+        P::Diff: Linear<Scalar = f32>,
+    {
+        let [ab, ac] = self.tangents();
+        self.0[0].pos.add(&ab.add(&ac).mul(1.0 / 3.0))
+    }
 }
 
 impl<A, B> Tri<Vertex2<A, B>> {
@@ -209,7 +220,8 @@ impl<A, B> Tri<Vertex2<A, B>> {
 impl<A, B> Tri<Vertex3<A, B>> {
     /// Returns the normal vector of `self`.
     ///
-    /// The result is normalized to unit length.
+    /// The result is normalized to unit length. If self is degenerate and
+    /// has no normal, returns a zero vector.
     ///
     /// # Examples
     /// ```
@@ -228,7 +240,7 @@ impl<A, B> Tri<Vertex3<A, B>> {
     pub fn normal(&self) -> Normal3 {
         let [t, u] = self.tangents();
         // TODO normal with basis
-        t.cross(&u).normalize().to()
+        t.cross(&u).normalize_or_zero().to()
     }
 
     /// Returns the plane that `self` lies on.

--- a/core/src/math/color.rs
+++ b/core/src/math/color.rs
@@ -122,6 +122,28 @@ impl<Ch, Sp, const N: usize> Color<[Ch; N], Sp> {
         Color::new(self.0.map(f))
     }
 }
+impl<Sp, const N: usize> Color<[f32; N], Sp> {
+    /// Returns `self` clamped channel-wise to the given range.
+    ///
+    /// In other words, for each channel `self[i]`, the result `r` has
+    /// `r[i]` equal to `self[i].clamp(min[i], max[i])`.
+    ///
+    /// # Examples
+    /// ```
+    /// use retrofire_core::math::color::{Color3f, gray, rgb};
+    /// let c: Color3f = rgb(0.0, 0.5, 1.0);
+    ///
+    /// let clamped = c.clamp(&gray(0.1), &gray(0.5));
+    /// assert_eq!(clamped, rgb(0.1, 0.5, 0.5));
+    // TODO f32 and f64 have inherent clamp methods because they're not Ord.
+    //      A generic clamp for Sc: Ord would conflict with this one. There is
+    //      currently no clean way to support both floats and impl Ord types.
+    //      However, ColorX should have its own inherent impls.
+    #[must_use]
+    pub fn clamp(&self, min: &Self, max: &Self) -> Self {
+        array::from_fn(|i| self[i].clamp(min[i], max[i])).into()
+    }
+}
 
 impl Color3<Rgb> {
     /// Returns `self` as RGBA, with alpha set to 0xFF (fully opaque).

--- a/core/src/math/mat.rs
+++ b/core/src/math/mat.rs
@@ -550,9 +550,10 @@ impl<Src, Dst> Mat4<Src, Dst> {
     /// use retrofire_core::assert_approx_eq;
     /// use retrofire_core::math::*;
     ///
-    /// let m = rotate_y(degs(90.0)).then(&translate3(1.0, 2.0, 3.0));
-    /// let lin = m.linear();
-    /// assert_approx_eq!(lin.apply(&pt3(1.0, 0.0, 0.0)), pt3(0.0, 0.0, -1.0));
+    /// let m = scale(splat(5.0)).then(&translate3(1.0, 2.0, 3.0));
+    /// let pt = pt3(1.0, 0.0, 0.0);
+    ///
+    /// assert_approx_eq!(m.linear().apply(&pt), pt3(5.0, 0.0, 0.0));
     pub const fn linear(&self) -> Mat3<Src, Dst, 3> {
         let [r, s, t, _] = self.0;
         mat![
@@ -569,10 +570,23 @@ impl<Src, Dst> Mat4<Src, Dst> {
     /// use retrofire_core::math::*;
     ///
     /// let trans = vec3(1.0, 2.0, 3.0);
-    /// let m = rotate_y(degs(45.0)).then(&translate(trans));
+    /// let m = scale(splat(5.0)).then(&translate(trans));
     /// assert_eq!(m.translation(), trans);
     pub const fn translation(&self) -> Vec3<Dst> {
         vec3(self.0[0][3], self.0[1][3], self.0[2][3])
+    }
+
+    /// Returns the translation column vector of `self` as a point.
+    ///
+    /// # Example
+    /// ```
+    /// use retrofire_core::math::*;
+    ///
+    /// let trans = vec3(1.0, 2.0, 3.0);
+    /// let m = scale(splat(5.0)).then(&translate(trans));
+    /// assert_eq!(m.origin(), pt3(1.0, 2.0, 3.0));
+    pub const fn origin(&self) -> Point3<Dst> {
+        self.translation().to_pt()
     }
 
     /// Returns the determinant of `self`.

--- a/core/src/math/vec.rs
+++ b/core/src/math/vec.rs
@@ -149,7 +149,7 @@ impl<Sp, const N: usize> Vector<[f32; N], Sp> {
     /// ```
     ///
     /// # Panics
-    /// Panics in dev mode if `self` is a zero vector.
+    /// Panics if the length of `self` is approximately zero.
     #[inline]
     #[must_use]
     pub fn normalize(&self) -> Self {
@@ -163,6 +163,34 @@ impl<Sp, const N: usize> Vector<[f32; N], Sp> {
             self.0
         );
         *self * f32::recip_sqrt(len_sqr)
+    }
+
+    /// Returns `self` normalized to unit length, or a zero vector if the
+    /// length of  `self` is approximately zero.
+    ///
+    /// # Examples
+    /// ```
+    /// use retrofire_core::assert_approx_eq;
+    /// use retrofire_core::math::{vec2, Vec2};
+    ///
+    /// let normalized: Vec2 = vec2(3.0, 4.0).normalize_or_zero();
+    /// assert_approx_eq!(normalized, vec2(0.6, 0.8), eps=1e-2);
+    ///
+    /// let zero: Vec2 = vec2(0.0, 0.0).normalize_or_zero();
+    /// assert_eq!(zero, vec2(0.0, 0.0));
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn normalize_or_zero(&self) -> Self {
+        #[cfg(feature = "std")]
+        use super::float::RecipSqrt;
+        use super::float::f32;
+        let len_sqr = self.len_sqr();
+        if len_sqr.approx_eq_eps(&0.0, &1e-12) {
+            Vector::zero()
+        } else {
+            *self * f32::recip_sqrt(len_sqr)
+        }
     }
 
     /// Returns `self` clamped component-wise to the given range.

--- a/core/src/render/batch.rs
+++ b/core/src/render/batch.rs
@@ -3,10 +3,8 @@
 use alloc::vec::Vec;
 use core::borrow::Borrow;
 
-use crate::{
-    geom::{Mesh, Tri, Vertex3},
-    math::{Mat4, Vary},
-};
+use crate::geom::{Edge, Mesh, Tri, Vertex3};
+use crate::math::{Mat4, Vary};
 
 use super::{Clip, Context, Ndc, Render, Screen, Shader, Target};
 
@@ -145,5 +143,30 @@ impl<Prim, Vtx, Uni, Shd, Tgt, Ctx> Batch<Prim, Vtx, Uni, Shd, Tgt, Ctx> {
             prims, verts, shader, *uniform, *viewport,
             target, (*ctx).borrow(),
         );
+    }
+}
+
+impl<Vtx, Uni, Shd, Tgt, Ctx> Batch<Edge<usize>, Vtx, Uni, Shd, Tgt, Ctx> {
+    pub fn append(&mut self, mut other: Self) {
+        let l = self.verts.len();
+        self.verts.extend(other.verts);
+        for edge in &mut other.prims {
+            edge.0 += l;
+            edge.1 += l;
+        }
+        self.prims.extend(other.prims);
+    }
+}
+
+impl<Vtx, Uni, Shd, Tgt, Ctx> Batch<Tri<usize>, Vtx, Uni, Shd, Tgt, Ctx> {
+    pub fn append(&mut self, mut other: Self) {
+        let l = self.verts.len();
+        self.verts.extend(other.verts);
+        for Tri([a, b, c]) in &mut other.prims {
+            *a += l;
+            *b += l;
+            *c += l;
+        }
+        self.prims.extend(other.prims);
     }
 }


### PR DESCRIPTION
* Color::clamp(): like in Vec and Point
* VecN::normalize_or_zero(): don't panic, return zero
* MatN::origin(): return the translation vector as a point
* Batch::append(): append the geometry of a batch to another
* Tri::centroid(): return the center point of a triangle