### PR TITLE
Change As(Mut)Slice2 type parameter to an associated type

### DIFF
--- a/core/src/render/tex.rs
+++ b/core/src/render/tex.rs
@@ -224,7 +224,7 @@ impl SamplerRepeatPot {
     /// Creates a new `SamplerRepeatPot` based on the dimensions of `tex`.
     /// # Panics
     /// If the width or height of `tex` is not a power of two.
-    pub fn new<C>(tex: &Texture<impl AsSlice2<C>>) -> Self {
+    pub fn new(tex: &Texture<impl AsSlice2>) -> Self {
         let w = tex.width() as u32;
         let h = tex.height() as u32;
         assert!(w.is_power_of_two(), "width must be 2^n, was {w}");
@@ -237,11 +237,11 @@ impl SamplerRepeatPot {
     ///
     /// Uses nearest neighbor sampling.
     #[inline]
-    pub fn sample<C: Copy>(
+    pub fn sample<D: AsSlice2<Elem: Copy>>(
         &self,
-        tex: &Texture<impl AsSlice2<C>>,
+        tex: &Texture<D>,
         tc: TexCoord,
-    ) -> C {
+    ) -> D::Elem {
         let scaled_uv = uv(tex.width() * tc.u(), tex.height() * tc.v());
         self.sample_abs(tex, scaled_uv)
     }
@@ -252,11 +252,11 @@ impl SamplerRepeatPot {
     ///
     /// Uses nearest neighbor sampling.
     #[inline]
-    pub fn sample_abs<C: Copy>(
+    pub fn sample_abs<D: AsSlice2<Elem: Copy>>(
         &self,
-        tex: &Texture<impl AsSlice2<C>>,
+        tex: &Texture<D>,
         tc: TexCoord,
-    ) -> C {
+    ) -> D::Elem {
         use crate::math::float::f32;
         // Convert first to signed int to avoid clamping to zero
         let u = f32::floor(tc.u()) as i32 as u32 & self.w_mask;
@@ -277,11 +277,11 @@ impl SamplerClamp {
     ///
     /// Uses nearest neighbor sampling.
     #[inline]
-    pub fn sample<C: Copy>(
+    pub fn sample<D: AsSlice2<Elem: Copy>>(
         &self,
-        tex: &Texture<impl AsSlice2<C>>,
+        tex: &Texture<D>,
         tc: TexCoord,
-    ) -> C {
+    ) -> D::Elem {
         self.sample_abs(tex, uv(tc.u() * tex.w, tc.v() * tex.h))
     }
 
@@ -291,11 +291,11 @@ impl SamplerClamp {
     ///
     /// Uses nearest neighbor sampling.
     #[inline]
-    pub fn sample_abs<C: Copy>(
+    pub fn sample_abs<D: AsSlice2<Elem: Copy>>(
         &self,
-        tex: &Texture<impl AsSlice2<C>>,
+        tex: &Texture<D>,
         tc: TexCoord,
-    ) -> C {
+    ) -> D::Elem {
         use crate::math::float::f32;
         let u = f32::floor(tc.u().clamp(0.0, tex.w - 1.0)) as u32;
         let v = f32::floor(tc.v().clamp(0.0, tex.h - 1.0)) as u32;
@@ -322,11 +322,11 @@ impl SamplerOnce {
     /// # Panics
     /// May panic if `tc` is not in the valid range.
     #[inline]
-    pub fn sample<C: Copy>(
+    pub fn sample<D: AsSlice2<Elem: Copy>>(
         &self,
-        tex: &Texture<impl AsSlice2<C>>,
+        tex: &Texture<D>,
         tc: TexCoord,
-    ) -> C {
+    ) -> D::Elem {
         let scaled_uv = uv(tex.width() * tc.u(), tex.height() * tc.v());
         self.sample_abs(tex, scaled_uv)
     }
@@ -340,11 +340,11 @@ impl SamplerOnce {
     /// # Panics
     /// May panic if `tc` is not in the valid range.
     #[inline]
-    pub fn sample_abs<C: Copy>(
+    pub fn sample_abs<D: AsSlice2<Elem: Copy>>(
         &self,
-        tex: &Texture<impl AsSlice2<C>>,
+        tex: &Texture<D>,
         tc: TexCoord,
-    ) -> C {
+    ) -> D::Elem {
         let u = tc.u() as u32;
         let v = tc.v() as u32;
 

--- a/core/src/util/buf.rs
+++ b/core/src/util/buf.rs
@@ -18,16 +18,18 @@ use inner::Inner;
 //
 
 /// A trait for types that can provide a view of their data as a [`Slice2`].
-pub trait AsSlice2<T> {
+pub trait AsSlice2 {
+    type Elem;
     /// Returns a borrowed `Slice2` view of `Self`.
-    fn as_slice2(&self) -> Slice2<'_, T>;
+    fn as_slice2(&self) -> Slice2<'_, Self::Elem>;
 }
 
 /// A trait for types that can provide a mutable view of their data
 /// as a [`MutSlice2`].
-pub trait AsMutSlice2<T> {
+pub trait AsMutSlice2 {
+    type Elem;
     /// Returns a mutably borrowed `MutSlice2` view of `Self`.
-    fn as_mut_slice2(&mut self) -> MutSlice2<'_, T>;
+    fn as_mut_slice2(&mut self) -> MutSlice2<'_, Self::Elem>;
 }
 
 //
@@ -266,44 +268,51 @@ impl<'a, T> MutSlice2<'a, T> {
 // Local trait impls
 //
 
-impl<T> AsSlice2<T> for Buf2<T> {
+impl<T> AsSlice2 for Buf2<T> {
+    type Elem = T;
     #[inline]
     fn as_slice2(&self) -> Slice2<'_, T> {
         self.0.as_slice2()
     }
 }
-impl<T> AsSlice2<T> for &Buf2<T> {
+impl<T> AsSlice2 for &Buf2<T> {
+    type Elem = T;
     #[inline]
     fn as_slice2(&self) -> Slice2<'_, T> {
         self.0.as_slice2()
     }
 }
-impl<T> AsSlice2<T> for Slice2<'_, T> {
+impl<T> AsSlice2 for Slice2<'_, T> {
+    type Elem = T;
     #[inline]
     fn as_slice2(&self) -> Slice2<'_, T> {
         self.0.as_slice2()
     }
 }
-impl<T> AsSlice2<T> for MutSlice2<'_, T> {
+impl<T> AsSlice2 for MutSlice2<'_, T> {
+    type Elem = T;
     #[inline]
     fn as_slice2(&self) -> Slice2<'_, T> {
         self.0.as_slice2()
     }
 }
 
-impl<T> AsMutSlice2<T> for Buf2<T> {
+impl<T> AsMutSlice2 for Buf2<T> {
+    type Elem = T;
     #[inline]
     fn as_mut_slice2(&mut self) -> MutSlice2<'_, T> {
         self.0.as_mut_slice2()
     }
 }
-impl<T> AsMutSlice2<T> for &mut Buf2<T> {
+impl<T> AsMutSlice2 for &mut Buf2<T> {
+    type Elem = T;
     #[inline]
     fn as_mut_slice2(&mut self) -> MutSlice2<'_, T> {
         self.0.as_mut_slice2()
     }
 }
-impl<T> AsMutSlice2<T> for MutSlice2<'_, T> {
+impl<T> AsMutSlice2 for MutSlice2<'_, T> {
+    type Elem = T;
     #[inline]
     fn as_mut_slice2(&mut self) -> MutSlice2<'_, T> {
         self.0.as_mut_slice2()
@@ -637,7 +646,7 @@ pub mod inner {
         /// # Panics
         /// if the dimensions of `self` and `other` do not match.
         #[doc(alias = "blit")]
-        pub fn copy_from(&mut self, other: impl AsSlice2<T>)
+        pub fn copy_from(&mut self, other: impl AsSlice2<Elem = T>)
         where
             T: Copy,
         {
@@ -1050,7 +1059,7 @@ mod tests {
 
     #[test]
     fn buf_ref_as_slice() {
-        fn foo<T: AsSlice2<u32>>(buf: T) -> u32 {
+        fn foo<T: AsSlice2<Elem = u32>>(buf: T) -> u32 {
             buf.as_slice2().width()
         }
         let buf = Buf2::new((2, 2));
@@ -1060,7 +1069,7 @@ mod tests {
 
     #[test]
     fn buf_ref_as_slice_mut() {
-        fn foo<T: AsMutSlice2<u32>>(mut buf: T) {
+        fn foo<T: AsMutSlice2<Elem = u32>>(mut buf: T) {
             buf.as_mut_slice2()[[1, 1]] = 42;
         }
         let mut buf = Buf2::new((2, 2));

--- a/core/src/util/pnm.rs
+++ b/core/src/util/pnm.rs
@@ -278,12 +278,10 @@ pub fn parse_pnm(input: impl IntoIterator<Item = u8>) -> Result<Buf2<Color3>> {
 /// # Errors
 /// Returns [`std::io::Error`] if an error occurs while writing.
 #[cfg(feature = "std")]
-pub fn save_ppm<T>(
-    path: impl AsRef<Path>,
-    data: impl AsSlice2<T>,
-) -> io::Result<()>
+pub fn save_ppm<D>(path: impl AsRef<Path>, data: D) -> io::Result<()>
 where
-    T: IntoPixel<[u8; 3], Rgb888> + Copy,
+    D: AsSlice2,
+    D::Elem: IntoPixel<[u8; 3], Rgb888> + Copy,
 {
     let out = BufWriter::new(File::create(path)?);
     write_ppm(out, data)
@@ -295,12 +293,10 @@ where
 /// # Errors
 /// Returns [`std::io::Error`] if an error occurs while writing.
 #[cfg(feature = "std")]
-pub fn write_ppm<T>(
-    mut out: impl io::Write,
-    data: impl AsSlice2<T>,
-) -> io::Result<()>
+pub fn write_ppm<D>(mut out: impl io::Write, data: D) -> io::Result<()>
 where
-    T: IntoPixel<[u8; 3], Rgb888> + Copy,
+    D: AsSlice2,
+    D::Elem: IntoPixel<[u8; 3], Rgb888> + Copy,
 {
     let slice = data.as_slice2();
     Header {

--- a/front/src/lib.rs
+++ b/front/src/lib.rs
@@ -89,17 +89,19 @@ pub mod dims {
     pub const UWQHD_3440_1440: Dims = (3440, 1440);
 }
 
-impl<W, C: AsMutSlice2<u32>, F: Copy, Z: AsMutSlice2<f32>>
-    Frame<'_, W, &RefCell<Framebuf<Colorbuf<C, F>, Z>>>
+impl<Win, Fmt, Cbuf, Zbuf>
+    Frame<'_, Win, &RefCell<Framebuf<Colorbuf<Cbuf, Fmt>, Zbuf>>>
 where
-    Color4: IntoPixel<u32, F>,
+    Fmt: Copy,
+    Cbuf: AsMutSlice2<Elem: Clone>,
+    Zbuf: AsMutSlice2<Elem = f32>,
+    Color4: IntoPixel<Cbuf::Elem, Fmt>,
 {
     /// Clears the color buffer if [color clearing][Context::color_clear]
     /// is enabled and the depth buffer if [depth clearing][Context::depth_clear]
     /// is enabled.
     pub fn clear(&mut self) {
         if let Some(c) = self.ctx.color_clear {
-            // TODO Assumes pixel format
             self.buf
                 .borrow_mut()
                 .color_buf


### PR DESCRIPTION
This is a better match and allows making various Target impls generic over any pixel format. The custom Framebuf type for SDL2 could be removed.